### PR TITLE
Enhance Team Builder with threat score calculations and sorting options

### DIFF
--- a/components/team-builder/SelectorMatchupGrid.tsx
+++ b/components/team-builder/SelectorMatchupGrid.tsx
@@ -1,5 +1,6 @@
 import type { MatchupSlotCell } from "@/lib/dex";
 import {
+  defThreatScoreFromSlots,
   multiplierToEffectivenessTier,
   type EffectivenessTier,
 } from "@/lib/dex";
@@ -38,6 +39,7 @@ function TierSwatch({
  * Each filled slot shows attack | defense effectiveness as two color bands.
  */
 export function SelectorMatchupGrid({ slots }: SelectorMatchupGridProps) {
+  const threatScore = defThreatScoreFromSlots(slots);
   const labelParts = slots.map((cell, i) =>
     cell
       ? `slot ${i + 1} attack ${cell.atkExplanation}; defense ${cell.defExplanation}`
@@ -45,11 +47,19 @@ export function SelectorMatchupGrid({ slots }: SelectorMatchupGridProps) {
   );
 
   return (
-    <div
-      className="grid w-full grid-cols-2 grid-rows-3 gap-1"
-      role="group"
-      aria-label={`Matchups vs team: ${labelParts.join("; ")}`}
-    >
+    <div className="flex w-full flex-col gap-1">
+      <p
+        className="text-center text-[10px] font-semibold tabular-nums text-black/60"
+        title="Per team slot (right/defense band): +2 if this Pokemon's STAB is 2x vs your slot, +4 if 4x or more. Neutral/resisted add 0."
+        aria-label={`Defensive threat score ${threatScore}`}
+      >
+        Threat {threatScore}
+      </p>
+      <div
+        className="grid w-full grid-cols-2 grid-rows-3 gap-1"
+        role="group"
+        aria-label={`Matchups vs team: ${labelParts.join("; ")}`}
+      >
       {slots.map((cell, i) => (
         <div
           key={i}
@@ -82,6 +92,7 @@ export function SelectorMatchupGrid({ slots }: SelectorMatchupGridProps) {
           )}
         </div>
       ))}
+      </div>
     </div>
   );
 }

--- a/components/team-builder/TeamBuilderScreen.tsx
+++ b/components/team-builder/TeamBuilderScreen.tsx
@@ -16,6 +16,7 @@ import {
   NATIONAL_VIEW_ID,
   TYPE_NAMES,
   computeSelectorTeamMatchupPerSlot,
+  defThreatScoreFromSlots,
   formatTypeLabel,
   type MatchupSlotCell,
   dexObject,
@@ -132,6 +133,9 @@ export function TeamBuilderScreen() {
   );
   const [typeFilterA, setTypeFilterA] = useState<TypeName | null>(null);
   const [typeFilterB, setTypeFilterB] = useState<TypeName | null>(null);
+  const [gridSort, setGridSort] = useState<
+    "default" | "threat-desc" | "threat-asc"
+  >("default");
   const [flashSlotIndex, setFlashSlotIndex] = useState<number | null>(null);
   const flashClearTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
@@ -186,6 +190,19 @@ export function TeamBuilderScreen() {
     }
     return m;
   }, [selectorNames, teamSlots]);
+
+  const sortedSelectorNames = useMemo(() => {
+    const rows = selectorNames.slice();
+    if (gridSort === "default") return rows;
+    return rows.sort((a, b) => {
+      const sa = defThreatScoreFromSlots(matchupByKey.get(a.entry.key) ?? []);
+      const sb = defThreatScoreFromSlots(matchupByKey.get(b.entry.key) ?? []);
+      if (sa !== sb) {
+        return gridSort === "threat-desc" ? sb - sa : sa - sb;
+      }
+      return a.label.localeCompare(b.label);
+    });
+  }, [selectorNames, gridSort, matchupByKey]);
 
   const handleSlotDrop = useCallback((slotIndex: number, e: React.DragEvent) => {
     e.preventDefault();
@@ -340,6 +357,29 @@ export function TeamBuilderScreen() {
             <div className="flex w-full shrink-0 flex-wrap items-end justify-end gap-2 sm:gap-3">
               <div className="flex min-w-0 flex-col items-end gap-1">
                 <label
+                  htmlFor="team-builder-sort"
+                  className="text-[10px] font-semibold uppercase tracking-wide text-black/45"
+                >
+                  Sort
+                </label>
+                <select
+                  id="team-builder-sort"
+                  value={gridSort}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (v === "threat-desc" || v === "threat-asc") setGridSort(v);
+                    else setGridSort("default");
+                  }}
+                  className="min-w-[11rem] max-w-full rounded-md border border-black/25 bg-white/80 px-2 py-1.5 text-right text-xs text-black shadow-sm"
+                  aria-label="Sort Pokémon grid"
+                >
+                  <option value="default">Default (unsorted)</option>
+                  <option value="threat-desc">Threat (high → low)</option>
+                  <option value="threat-asc">Threat (low → high)</option>
+                </select>
+              </div>
+              <div className="flex min-w-0 flex-col items-end gap-1">
+                <label
                   htmlFor="team-builder-type-a"
                   className="text-[10px] font-semibold uppercase tracking-wide text-black/45"
                 >
@@ -417,7 +457,7 @@ export function TeamBuilderScreen() {
                   className="grid list-none grid-cols-3 gap-4 sm:gap-5"
                   aria-label="Pokémon available for your team"
                 >
-                  {selectorNames.flatMap(({ entry, label }, i) => {
+                  {sortedSelectorNames.flatMap(({ entry, label }, i) => {
                     const nodes: ReactNode[] = [];
                     if (i > 0 && i % SELECTOR_ROW_BREAK_EVERY === 0) {
                       nodes.push(

--- a/lib/dex/index.ts
+++ b/lib/dex/index.ts
@@ -45,6 +45,7 @@ export {
   bestStabMultiplier,
   computeSelectorTeamMatchupPerSlot,
   computeSelectorTeamMatchupTotals,
+  defThreatScoreFromSlots,
   formatEffectivenessMultiplier,
   getBestStabMatchupBreakdown,
   getDominantMatchupScore,

--- a/lib/dex/matchupScores.ts
+++ b/lib/dex/matchupScores.ts
@@ -160,6 +160,24 @@ export function computeSelectorTeamMatchupPerSlot(
 }
 
 /**
+ * Team Builder threat: sum over filled slots using the **def** band only (selector STAB
+ * attacking your team member). Resisted/neutral slots add 0; 2× adds 2; 4× or higher adds 4.
+ */
+export function defThreatScoreFromSlots(
+  slots: readonly (MatchupSlotCell | null)[],
+): number {
+  let total = 0;
+  for (const cell of slots) {
+    if (!cell) continue;
+    const m = cell.defMultiplier;
+    if (m <= 1 + 1e-9) continue;
+    if (m <= 2 + 1e-9) total += 2;
+    else total += 4;
+  }
+  return total;
+}
+
+/**
  * Sums per-slot discrete scores (filled slots only) to [-24, 24] each.
  */
 export function computeSelectorTeamMatchupTotals(


### PR DESCRIPTION
- Added `defThreatScoreFromSlots` function to calculate defensive threat scores based on filled slots.
- Updated `SelectorMatchupGrid` to display the calculated threat score.
- Introduced sorting options in `TeamBuilderScreen` to sort Pokémon by threat score (high to low, low to high).
- Refactored relevant components to integrate new threat score functionality and sorting logic.