### PR TITLE
Enhance DexRecordDetailModal with attacker vs defender stats display

### DIFF
--- a/components/dex/components/DexRecordDetailModal.tsx
+++ b/components/dex/components/DexRecordDetailModal.tsx
@@ -2,11 +2,17 @@
 
 import { useEffect, useMemo } from "react";
 
+import {
+  PhysicalDamageCategoryIcon,
+  SpecialDamageCategoryIcon,
+} from "@/components/dex/components/MoveDamageCategoryIcons";
 import { TypeBadges } from "@/components/team-builder/TypeBadges";
 import {
   DEX_STAT_TODO,
+  attackerVsDefenderBaseStatDiffs,
   classifyDexEntriesByBestStabVsDefender,
   formatDexTileDisplayName,
+  formatSignedBaseStatDiff,
   getDexEntryTypeNames,
 } from "@/lib/dex";
 import type { DexDisplayEntry } from "@/lib/dex";
@@ -33,10 +39,12 @@ function statPill(label: string, value: number | undefined) {
 function MatchupColumn({
   title,
   subtitle,
+  defender,
   entries,
 }: {
   title: string;
   subtitle: string;
+  defender: DexDisplayEntry;
   entries: DexDisplayEntry[];
 }) {
   return (
@@ -52,17 +60,30 @@ function MatchupColumn({
         {entries.length === 0 ? (
           <li className="px-2 py-4 text-center text-sm text-black/45">None</li>
         ) : (
-          entries.map((e) => (
-            <li
-              key={e.key}
-              className="flex flex-col gap-1 rounded-lg border border-transparent px-2 py-1.5 hover:border-black/10 hover:bg-white/80"
-            >
-              <span className="text-sm font-medium leading-snug text-black">
-                {formatDexTileDisplayName(e.dexName, e.formId)}
-              </span>
-              <TypeBadges typeNames={getDexEntryTypeNames(e)} size="compact" />
-            </li>
-          ))
+          entries.map((e) => {
+            const { phys, spec } = attackerVsDefenderBaseStatDiffs(e, defender);
+            return (
+              <li
+                key={e.key}
+                className="flex flex-col gap-1 rounded-lg border border-transparent px-2 py-1.5 hover:border-black/10 hover:bg-white/80"
+              >
+                <span className="text-sm font-medium leading-snug text-black">
+                  {formatDexTileDisplayName(e.dexName, e.formId)}
+                </span>
+                <TypeBadges typeNames={getDexEntryTypeNames(e)} size="compact" />
+                <div className="flex justify-between gap-3 text-xs tabular-nums text-black/55">
+                  <span className="flex min-w-0 items-center gap-1" title="Physical">
+                    <PhysicalDamageCategoryIcon className="shrink-0 text-orange-600" />
+                    {formatSignedBaseStatDiff(phys)}
+                  </span>
+                  <span className="flex min-w-0 items-center gap-1" title="Special">
+                    <SpecialDamageCategoryIcon className="shrink-0 text-sky-600" />
+                    {formatSignedBaseStatDiff(spec)}
+                  </span>
+                </div>
+              </li>
+            );
+          })
         )}
       </ul>
     </div>
@@ -161,16 +182,19 @@ export function DexRecordDetailModal({
             <MatchupColumn
               title="Neutral"
               subtitle="1× best STAB"
+              defender={record}
               entries={buckets.neutral}
             />
             <MatchupColumn
               title="Effective"
               subtitle="2× best STAB"
+              defender={record}
               entries={buckets.effective}
             />
             <MatchupColumn
               title="Super effective"
               subtitle="4× or higher best STAB"
+              defender={record}
               entries={buckets.superEffective}
             />
           </div>

--- a/components/dex/components/MoveDamageCategoryIcons.tsx
+++ b/components/dex/components/MoveDamageCategoryIcons.tsx
@@ -1,0 +1,44 @@
+/**
+ * Main-series-style damage category marks: physical (orange impact) vs special (blue rings).
+ * Same visual language as move lists (physical / special), not move types.
+ */
+export function PhysicalDamageCategoryIcon({
+  className,
+}: {
+  className?: string;
+}) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 16 16"
+      width={14}
+      height={14}
+      aria-hidden
+    >
+      <path
+        fill="currentColor"
+        d="M8 1l1.5 4.5L14 8l-4.5 1.5L8 14l-1.5-4.5L2 8l4.5-1.5z"
+      />
+    </svg>
+  );
+}
+
+export function SpecialDamageCategoryIcon({
+  className,
+}: {
+  className?: string;
+}) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 16 16"
+      width={14}
+      height={14}
+      aria-hidden
+    >
+      <circle cx="8" cy="8" r="6" fill="none" stroke="currentColor" strokeWidth="1.5" />
+      <circle cx="8" cy="8" r="3.25" fill="none" stroke="currentColor" strokeWidth="1.25" />
+      <circle cx="8" cy="8" r="1.15" fill="currentColor" />
+    </svg>
+  );
+}

--- a/lib/dex/attackerDefenderStatDiff.ts
+++ b/lib/dex/attackerDefenderStatDiff.ts
@@ -1,0 +1,82 @@
+import { DEX_STAT_TODO } from "./dexObject";
+import type { DexDisplayEntry } from "./display";
+import { formatDexTileDisplayName } from "./display";
+
+function isUsableBaseStat(n: number | undefined): n is number {
+  return n !== undefined && n !== DEX_STAT_TODO;
+}
+
+/**
+ * Physical / special “edges” for an attacker against a defender using **base stats** only.
+ *
+ * - **phys**: attacker `attack` minus defender `defense` (same units as base stats).
+ * - **spec**: attacker `spAtk` minus defender `spDef`.
+ *
+ * These mirror which side of the damage formula each stat enters (physical vs special).
+ *
+ * **Level ~100 (and fixed IV/EV/nature):** main-series stats use
+ * `floor((2×Base + IV + ⌊EV/4⌋) × Level/100 + 5) × nature`, so a gap in base stats
+ * scales to roughly **2×** that gap in actual stats when IV/EV are held constant.
+ * For **sorting** candidates against the *same* defender, subtracting the same defender
+ * defenses is enough—no z-score or population normalization is required. Relative order
+ * of gaps is stable for typical comparisons; treat values as an index, not exact damage.
+ */
+export function attackerVsDefenderBaseStatDiffs(
+  attacker: DexDisplayEntry,
+  defender: DexDisplayEntry,
+): { phys: number | null; spec: number | null } {
+  const a = attacker.form;
+  const d = defender.form;
+  if (!a || !d) return { phys: null, spec: null };
+
+  const phys =
+    isUsableBaseStat(a.attack) && isUsableBaseStat(d.defense)
+      ? a.attack - d.defense
+      : null;
+  const spec =
+    isUsableBaseStat(a.spAtk) && isUsableBaseStat(d.spDef)
+      ? a.spAtk - d.spDef
+      : null;
+
+  return { phys, spec };
+}
+
+function maxEdge(d: { phys: number | null; spec: number | null }): number {
+  const p = d.phys ?? -Infinity;
+  const s = d.spec ?? -Infinity;
+  return Math.max(p, s);
+}
+
+/**
+ * Sort attackers against a fixed defender: stronger overall matchup edge first
+ * (max of phys/spec gap), then phys gap, then spec gap, then name.
+ */
+export function compareDexEntriesByAttackerVsDefenderStats(
+  a: DexDisplayEntry,
+  b: DexDisplayEntry,
+  defender: DexDisplayEntry,
+): number {
+  const da = attackerVsDefenderBaseStatDiffs(a, defender);
+  const db = attackerVsDefenderBaseStatDiffs(b, defender);
+
+  const primary = maxEdge(db) - maxEdge(da);
+  if (primary !== 0) return primary;
+
+  const physTie = (db.phys ?? -Infinity) - (da.phys ?? -Infinity);
+  if (physTie !== 0) return physTie;
+
+  const specTie = (db.spec ?? -Infinity) - (da.spec ?? -Infinity);
+  if (specTie !== 0) return specTie;
+
+  return formatDexTileDisplayName(a.dexName, a.formId).localeCompare(
+    formatDexTileDisplayName(b.dexName, b.formId),
+  );
+}
+
+/** Compact signed integer for UI (e.g. "+12", "-3"). */
+export function formatSignedBaseStatDiff(n: number | null): string {
+  if (n === null) return "—";
+  if (n === 0) return "0";
+  const sign = n > 0 ? "+" : "-";
+  return sign + Math.abs(n);
+}

--- a/lib/dex/index.ts
+++ b/lib/dex/index.ts
@@ -42,6 +42,12 @@ export type { DexDisplayEntry } from "./display";
 export { TYPE_BADGE_CLASSES, formatTypeLabel } from "./typeBadgeStyles";
 
 export {
+  attackerVsDefenderBaseStatDiffs,
+  compareDexEntriesByAttackerVsDefenderStats,
+  formatSignedBaseStatDiff,
+} from "./attackerDefenderStatDiff";
+
+export {
   bestStabMultiplier,
   classifyDexEntriesByBestStabVsDefender,
   computeSelectorTeamMatchupPerSlot,

--- a/lib/dex/matchupScores.ts
+++ b/lib/dex/matchupScores.ts
@@ -1,5 +1,6 @@
+import { compareDexEntriesByAttackerVsDefenderStats } from "./attackerDefenderStatDiff";
 import type { DexDisplayEntry } from "./display";
-import { formatDexTileDisplayName, getDexEntryTypeNames } from "./display";
+import { getDexEntryTypeNames } from "./display";
 import { formatTypeLabel } from "./typeBadgeStyles";
 import { TYPES } from "./types";
 import type { TypeName } from "./types";
@@ -243,10 +244,8 @@ export function classifyDexEntriesByBestStabVsDefender(
     else if (Math.abs(m - 1) < 1e-9) neutral.push(entry);
   }
 
-  const sortKey = (e: DexDisplayEntry) =>
-    formatDexTileDisplayName(e.dexName, e.formId);
   const sort = (a: DexDisplayEntry, b: DexDisplayEntry) =>
-    sortKey(a).localeCompare(sortKey(b));
+    compareDexEntriesByAttackerVsDefenderStats(a, b, defender);
 
   neutral.sort(sort);
   effective.sort(sort);


### PR DESCRIPTION
- Introduced PhysicalDamageCategoryIcon and SpecialDamageCategoryIcon components for visual representation of damage categories.
- Updated MatchupColumn to display physical and special stat differences between attacker and defender.
- Added utility functions for calculating and formatting base stat differences in attacker vs defender scenarios.
- Refactored sorting logic in classifyDexEntriesByBestStabVsDefender to utilize new comparison functions for better matchup accuracy.